### PR TITLE
fix(compliance): make the cookie banner responsive on mobile

### DIFF
--- a/packages/compliance/src/CookieBanner.module.css
+++ b/packages/compliance/src/CookieBanner.module.css
@@ -4,9 +4,9 @@
   inset-inline-start: 50%;
   transform: translateX(-50%);
   z-index: 9999;
-  width: 90%;
-  min-width: 560px;
-  max-width: 640px;
+  /* Cap at 640px on desktop but never exceed the viewport (minus a 1rem gutter
+     each side), so it stays on-screen on phones instead of overflowing. */
+  width: min(640px, calc(100vw - 2rem));
   background-color: var(--color-surface-charcoal);
   color: var(--color-on-dark);
   border-radius: 12px;
@@ -24,11 +24,14 @@
 
 .actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
 }
 
 .acceptButton {
-  flex: 1;
+  /* grow to fill, but with an 8rem basis so the two buttons stack instead of
+     squashing when the banner is narrow (small phones). */
+  flex: 1 1 8rem;
   padding: 0.625rem 1rem;
   border-radius: 9999px;
   border: none;
@@ -41,7 +44,7 @@
 }
 
 .rejectButton {
-  flex: 1;
+  flex: 1 1 8rem;
   padding: 0.625rem 1rem;
   border-radius: 9999px;
   border: 1.5px solid var(--color-on-dark-subtle);


### PR DESCRIPTION
The banner had min-width: 560px, so on phones (~360px) the centered banner overflowed both edges and clipped the message and buttons.

- Width is now min(640px, calc(100vw - 2rem)): capped at 640px on desktop, never wider than the viewport (1rem gutter each side) on mobile.
- Actions wrap (flex-wrap) and each button uses flex: 1 1 8rem, so Accept/ Reject sit side by side when there's room and stack on very narrow screens instead of squashing.

Verified at 375x812: banner fits fully, no horizontal page overflow.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Testing

- [ ] Unit tests pass (`pnpm test`)
- [ ] E2E tests pass (`pnpm test:e2e`)
- [ ] Type check passes (`pnpm typecheck`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Tested locally in browser

## Screenshots

<!-- If UI changes, add before/after screenshots -->

## Notes

<!-- Anything reviewers should know -->
