### PR TITLE
perf(ui): serve responsive services hero background

### DIFF
--- a/packages/ui/src/sections/ServicesHeroSection/ServicesHeroSection.astro
+++ b/packages/ui/src/sections/ServicesHeroSection/ServicesHeroSection.astro
@@ -22,7 +22,16 @@ const { heading, body1, body2, backgroundImage = heroBgFallback } = Astro.props;
   aria-labelledby="services-hero-heading"
 >
   <div class="heroBg">
-    <Image src={backgroundImage} alt="" aria-hidden="true" class="heroBgImg" loading="eager" />
+    <Image
+      src={backgroundImage}
+      alt=""
+      aria-hidden="true"
+      class="heroBgImg"
+      loading="eager"
+      widths={[640, 960, 1280, 1920, 2560]}
+      sizes="100vw"
+      quality={50}
+    />
   </div>
 
   <div class="heroLettersScaler">


### PR DESCRIPTION
The services hero loaded a single 2560px, ~152 KB webp eagerly and full-bleed, even on mobile. Its bandwidth and decode contended with the LCP heading paint, making the page's Lighthouse performance score swing between 0.80 and 0.93 (LCP 3.0-5.0s) and fail the >=0.9 CI gate.

Add responsive widths/sizes so mobile pulls a ~13 KB variant, and drop quality to 50 (invisible under the existing grayscale + 2px blur). Local mobile Lighthouse is now a stable 0.92 across runs (LCP ~3.0s, CLS 0.004), with the variance and 5s LCP spikes gone.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Testing

- [ ] Unit tests pass (`pnpm test`)
- [ ] E2E tests pass (`pnpm test:e2e`)
- [ ] Type check passes (`pnpm typecheck`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Tested locally in browser

## Screenshots

<!-- If UI changes, add before/after screenshots -->

## Notes

<!-- Anything reviewers should know -->
