### PR TITLE
fix(ui): reset spent Turnstile token and surface API errors on forms

### DIFF
--- a/packages/ui/src/compositions/ContactForm/ContactForm.test.tsx
+++ b/packages/ui/src/compositions/ContactForm/ContactForm.test.tsx
@@ -2,10 +2,14 @@ import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { trackEvent } from '@bool/analytics';
-import { submitContactForm } from '@bool/api';
+import { ApiError, submitContactForm } from '@bool/api';
 import ContactForm from './ContactForm';
 
-vi.mock('@bool/api', () => ({
+const { captchaReset } = vi.hoisted(() => ({ captchaReset: vi.fn() }));
+
+// Keep the real ApiError export so the form's `err instanceof ApiError` check works.
+vi.mock('@bool/api', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   submitContactForm: vi.fn(() => Promise.resolve()),
 }));
 
@@ -13,16 +17,17 @@ vi.mock('@bool/analytics', () => ({
   trackEvent: vi.fn(),
 }));
 
-vi.mock('../Captcha/Captcha', () => ({
-  default: ({
+vi.mock('../Captcha/Captcha', async () => {
+  const { useImperativeHandle } = await import('react');
+  const MockCaptcha = ({
     onVerify,
+    ref,
   }: {
     onVerify: (token: string) => void;
-    onExpire?: () => void;
-    siteKey: string;
-    theme?: string;
-    ref?: React.Ref<unknown>;
+    ref?: React.Ref<{ reset: () => void; execute: () => Promise<string> }>;
   }) => {
+    // execute() returns '' so an un-clicked widget behaves like "not verified".
+    useImperativeHandle(ref, () => ({ reset: captchaReset, execute: () => Promise.resolve('') }));
     return (
       <button
         type="button"
@@ -32,8 +37,9 @@ vi.mock('../Captcha/Captcha', () => ({
         Verify
       </button>
     );
-  },
-}));
+  };
+  return { default: MockCaptcha };
+});
 
 afterEach(() => {
   cleanup();
@@ -148,7 +154,7 @@ describe('ContactForm', { timeout: 15_000 }, () => {
     });
   });
 
-  it('shows error message when API call fails', async () => {
+  it('shows error message and resets the captcha when API call fails', async () => {
     const user = userEvent.setup();
     vi.mocked(submitContactForm).mockRejectedValueOnce(new Error('API Error'));
 
@@ -167,6 +173,33 @@ describe('ContactForm', { timeout: 15_000 }, () => {
     await waitFor(() => {
       expect(screen.getByText('Something went wrong. Please try again.')).toBeInTheDocument();
     });
+    // The spent, single-use token must be cleared so a retry runs a fresh challenge.
+    expect(captchaReset).toHaveBeenCalled();
+  });
+
+  it('maps a 403 to the captcha message instead of the generic error', async () => {
+    const user = userEvent.setup();
+    vi.mocked(submitContactForm).mockRejectedValueOnce(
+      new ApiError(403, { error: 'CAPTCHA validation failed. Please try again.' })
+    );
+
+    render(<ContactForm layout="simple" captchaSiteKey="test-key" labels={labels} />);
+
+    await user.type(screen.getByLabelText('Name'), 'John Doe');
+    await user.type(screen.getByLabelText('Email'), 'john@example.com');
+    await user.type(
+      screen.getByLabelText('Message'),
+      'This is a test message that is long enough.'
+    );
+
+    await user.click(screen.getByTestId('mock-captcha'));
+    await user.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Please complete the captcha.')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Something went wrong. Please try again.')).not.toBeInTheDocument();
+    expect(captchaReset).toHaveBeenCalled();
   });
 
   it('has correct aria-label on form', () => {

--- a/packages/ui/src/compositions/ContactForm/ContactForm.tsx
+++ b/packages/ui/src/compositions/ContactForm/ContactForm.tsx
@@ -3,7 +3,7 @@ import { CheckCircle } from 'lucide-react';
 import { useCallback, useId, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { trackEvent } from '@bool/analytics';
-import { submitContactForm } from '@bool/api';
+import { ApiError, submitContactForm } from '@bool/api';
 import {
   contactFormSchema,
   contactFormSimpleSchema,
@@ -94,11 +94,19 @@ export default function ContactForm({
         reset();
         setCaptchaToken('');
         captchaRef.current?.reset();
-      } catch {
-        setError('root', { message: labels.error });
+      } catch (err) {
+        // The Turnstile token is single-use and now spent, so always reset the
+        // widget — the next submit runs a fresh challenge. A 403 means the token
+        // failed server-side validation, so surface the captcha label rather
+        // than the generic error.
+        const message =
+          err instanceof ApiError && err.status === 403 ? labels.captchaRequired : labels.error;
+        setError('root', { message });
+        setCaptchaToken('');
+        captchaRef.current?.reset();
       }
     },
-    [captchaSiteKey, captchaToken, layout, labels.error, reset, setError]
+    [captchaSiteKey, captchaToken, layout, labels.captchaRequired, labels.error, reset, setError]
   );
 
   function handleCaptchaVerify(token: string) {

--- a/packages/ui/src/compositions/NewsletterForm/NewsletterForm.test.tsx
+++ b/packages/ui/src/compositions/NewsletterForm/NewsletterForm.test.tsx
@@ -3,7 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import NewsletterForm from './NewsletterForm';
 
-vi.mock('@bool/api', () => ({
+const { captchaReset } = vi.hoisted(() => ({ captchaReset: vi.fn() }));
+
+// Keep the real ApiError export so the form's `err instanceof ApiError` check works.
+vi.mock('@bool/api', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   submitNewsletter: vi.fn(),
 }));
 
@@ -11,13 +15,24 @@ vi.mock('@bool/analytics', () => ({
   trackEvent: vi.fn(),
 }));
 
-vi.mock('../Captcha/Captcha', () => ({
-  default: ({ onVerify }: { onVerify: (t: string) => void }) => (
-    <button type="button" onClick={() => onVerify('test-token')}>
-      Verify Captcha
-    </button>
-  ),
-}));
+vi.mock('../Captcha/Captcha', async () => {
+  const { useImperativeHandle } = await import('react');
+  const MockCaptcha = ({
+    onVerify,
+    ref,
+  }: {
+    onVerify: (t: string) => void;
+    ref?: React.Ref<{ reset: () => void; execute: () => Promise<string> }>;
+  }) => {
+    useImperativeHandle(ref, () => ({ reset: captchaReset, execute: () => Promise.resolve('') }));
+    return (
+      <button type="button" onClick={() => onVerify('test-token')}>
+        Verify Captcha
+      </button>
+    );
+  };
+  return { default: MockCaptcha };
+});
 
 afterEach(() => {
   cleanup();
@@ -103,7 +118,7 @@ describe('NewsletterForm', () => {
     );
   });
 
-  it('shows error message on API failure', async () => {
+  it('shows error message on API failure and resets the captcha', async () => {
     const { submitNewsletter } = await import('@bool/api');
     vi.mocked(submitNewsletter).mockRejectedValueOnce(new Error('Network error'));
 
@@ -117,5 +132,57 @@ describe('NewsletterForm', () => {
     await user.click(screen.getByRole('button', { name: 'Subscribe' }));
 
     expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+    expect(captchaReset).toHaveBeenCalled();
+  });
+
+  it('shows the error message even without a captcha site key', async () => {
+    const { submitNewsletter } = await import('@bool/api');
+    vi.mocked(submitNewsletter).mockRejectedValueOnce(new Error('Network error'));
+
+    const user = userEvent.setup();
+    render(<NewsletterForm captchaSiteKey="" labels={labels} />);
+
+    await user.type(screen.getByLabelText('Name'), 'John Doe');
+    await user.type(screen.getByLabelText('Email address'), 'test@example.com');
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Subscribe' }));
+
+    // Regression: the error used to live inside the captcha block and stayed
+    // hidden when no widget was mounted.
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('shows a distinct invalid-email message instead of the generic error', async () => {
+    const user = userEvent.setup();
+    render(<NewsletterForm captchaSiteKey="test-key" labels={labels} />);
+
+    // "test@nodot" passes the input's lax native type=email check (so the form
+    // actually submits) but fails the stricter Zod schema — the gap where the
+    // Zod email message is the one the user sees.
+    await user.type(screen.getByLabelText('Name'), 'John Doe');
+    await user.type(screen.getByLabelText('Email address'), 'test@nodot');
+    await user.click(screen.getByRole('button', { name: 'Subscribe' }));
+
+    expect(await screen.findByText('Invalid email address')).toBeInTheDocument();
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+  });
+
+  it('maps a 403 to the captcha-needed message', async () => {
+    const { submitNewsletter, ApiError } = await import('@bool/api');
+    vi.mocked(submitNewsletter).mockRejectedValueOnce(
+      new ApiError(403, { error: 'CAPTCHA validation failed. Please try again.' })
+    );
+
+    const user = userEvent.setup();
+    render(<NewsletterForm captchaSiteKey="test-key" labels={labels} />);
+
+    await user.type(screen.getByLabelText('Name'), 'John Doe');
+    await user.type(screen.getByLabelText('Email address'), 'test@example.com');
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Verify Captcha' }));
+    await user.click(screen.getByRole('button', { name: 'Subscribe' }));
+
+    expect(await screen.findByText('Please complete the captcha')).toBeInTheDocument();
+    expect(captchaReset).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/compositions/NewsletterForm/NewsletterForm.tsx
+++ b/packages/ui/src/compositions/NewsletterForm/NewsletterForm.tsx
@@ -1,6 +1,6 @@
 import { useId, useRef, useState } from 'react';
 import { trackEvent } from '@bool/analytics';
-import { submitNewsletter } from '@bool/api';
+import { ApiError, submitNewsletter } from '@bool/api';
 import { newsletterSchema, ROUTES } from '@bool/shared';
 import { cn } from '@bool/shared';
 import { InlineInputButton } from '../../primitives/InlineInputButton/InlineInputButton';
@@ -39,15 +39,31 @@ export default function NewsletterForm({ variant = 'bar', captchaSiteKey, labels
   const [captchaToken, setCaptchaToken] = useState('');
   const [marketingConsent, setMarketingConsent] = useState(false);
   const [status, setStatus] = useState<
-    'idle' | 'loading' | 'success' | 'error' | 'captcha-needed' | 'consent-needed' | 'name-needed'
+    | 'idle'
+    | 'loading'
+    | 'success'
+    | 'error'
+    | 'captcha-needed'
+    | 'consent-needed'
+    | 'name-needed'
+    | 'email-needed'
   >('idle');
+  const [emailError, setEmailError] = useState('');
   const captchaRef = useRef<CaptchaHandle>(null);
 
   async function handleSubmit() {
     const validation = newsletterSchema.safeParse({ name, email });
     if (!validation.success) {
-      const hasNameIssue = validation.error.issues.some((i) => i.path[0] === 'name');
-      setStatus(hasNameIssue ? 'name-needed' : 'error');
+      const nameIssue = validation.error.issues.find((i) => i.path[0] === 'name');
+      if (nameIssue) {
+        setStatus('name-needed');
+      } else {
+        // No dedicated locale key for an invalid newsletter email; surface the
+        // schema's own message rather than the generic failure text.
+        const emailIssue = validation.error.issues.find((i) => i.path[0] === 'email');
+        setEmailError(emailIssue?.message ?? labels.error);
+        setStatus('email-needed');
+      }
       return;
     }
 
@@ -74,8 +90,13 @@ export default function NewsletterForm({ variant = 'bar', captchaSiteKey, labels
       setEmail('');
       setCaptchaToken('');
       captchaRef.current?.reset();
-    } catch {
-      setStatus('error');
+    } catch (err) {
+      // Token is single-use and now spent — reset the widget so the next submit
+      // runs a fresh challenge. A 403 is a failed token validation, so point the
+      // user at the captcha rather than showing the generic error.
+      setStatus(err instanceof ApiError && err.status === 403 ? 'captcha-needed' : 'error');
+      setCaptchaToken('');
+      captchaRef.current?.reset();
     }
   }
 
@@ -128,7 +149,10 @@ export default function NewsletterForm({ variant = 'bar', captchaSiteKey, labels
       {status === 'name-needed' && <p className={styles.consentError}>{labels.nameRequired}</p>}
       <InlineInputButton
         value={email}
-        onChange={setEmail}
+        onChange={(value) => {
+          setEmail(value);
+          if (status === 'email-needed') setStatus('idle');
+        }}
         onSubmit={() => void handleSubmit()}
         label={labels.label}
         placeholder={labels.placeholder}
@@ -136,6 +160,7 @@ export default function NewsletterForm({ variant = 'bar', captchaSiteKey, labels
         disabled={isDisabled}
         type="email"
       />
+      {status === 'email-needed' && <p className={styles.consentError}>{emailError}</p>}
       <label
         className={cn(styles.consentLabel, isBar ? styles.consentLabelBar : styles.consentLabelCta)}
       >
@@ -169,12 +194,14 @@ export default function NewsletterForm({ variant = 'bar', captchaSiteKey, labels
             theme={isBar ? 'light' : 'dark'}
             size="flexible"
           />
-          {status === 'captcha-needed' && (
-            <p className={styles.consentError}>{labels.captchaRequired}</p>
-          )}
-          {status === 'error' && <p className={styles.consentError}>{labels.error}</p>}
         </div>
       )}
+      {/* Kept outside the captcha wrapper so a failed submit is never silent,
+          even when the widget is not mounted (no site key / no input yet). */}
+      {status === 'captcha-needed' && (
+        <p className={styles.consentError}>{labels.captchaRequired}</p>
+      )}
+      {status === 'error' && <p className={styles.consentError}>{labels.error}</p>}
     </div>
   );
 }


### PR DESCRIPTION
Turnstile tokens are single-use: once a Lambda validates one, it is dead. ContactForm and NewsletterForm did not reset the widget on a failed submit, so every retry replayed the burnt token and got a 403 until the user reloaded. Always clear the token and reset the widget on failure, and map a 403 to the captcha label instead of the generic error so the user knows what to fix.

Also fix NewsletterForm error visibility: the error/captcha messages lived inside the {captchaSiteKey && hasInput} block and stayed hidden when no widget was mounted, and an invalid email collapsed into the generic failure text. Move the messages out of that block and give a Zod-invalid email (one that passes the native type=email check but fails the schema) its own message.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Testing

- [ ] Unit tests pass (`pnpm test`)
- [ ] E2E tests pass (`pnpm test:e2e`)
- [ ] Type check passes (`pnpm typecheck`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Tested locally in browser

## Screenshots

<!-- If UI changes, add before/after screenshots -->

## Notes

<!-- Anything reviewers should know -->
