### PR TITLE
fix(api): stop retrying 5xx and harden the api package config

### DIFF
--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -60,7 +60,7 @@ The site's only round-trip. Three forms, three routes, three Lambdas.
 
 ### `@bool/api`
 
-`submitters.ts` reads `PUBLIC_API_BASE_URL` (throws if missing), trims trailing slashes, and `POST`s JSON to `baseUrl + path`. `client.ts` (`apiFetch`) adds a 15s `AbortController` timeout and 2 retries with exponential backoff on `429`/`5xx`; anything else throws a typed `ApiError(status, body, operation)`. Request/response types live in `@bool/shared/src/types.ts` (`ContactFormData`, `NewsletterData`, `EventScheduleData`, `APIResponse`).
+`submitters.ts` reads `PUBLIC_API_BASE_URL` (throws if missing), trims trailing slashes, and `POST`s JSON to `baseUrl + path`. `client.ts` (`apiFetch`) adds a 15s `AbortController` timeout and 2 retries with exponential backoff on `429` and network errors/timeouts; any other status throws a typed `ApiError(status, body, operation)` immediately — `5xx` is never retried because the single-use Turnstile token in the body is consumed by the first attempt, so a replay can only fail CAPTCHA validation. Request/response types live in `@bool/shared/src/types.ts` (`ContactFormData`, `NewsletterData`, `EventScheduleData`, `APIResponse`).
 
 ### Backend (external, not in this repo)
 

--- a/documentation/security.md
+++ b/documentation/security.md
@@ -72,7 +72,7 @@ Zod schemas in `@bool/shared` (`src/validation.ts`) validate form input client-s
 | `contactFormSimpleSchema` | `name` 2–100; valid `email`; `message` 10–2000                                                               |
 | `newsletterSchema`        | `name` 2–100; valid `email`                                                                                  |
 
-The `@bool/api` client (`src/client.ts`) sets a 15s timeout via `AbortController`, retries twice with exponential backoff on `429`/`5xx` only, and throws a typed `ApiError` otherwise.
+The `@bool/api` client (`src/client.ts`) sets a 15s timeout via `AbortController`, retries twice with exponential backoff on `429` and network errors only, and throws a typed `ApiError` otherwise. `5xx` is not retried — the single-use Turnstile token was already consumed, so a replay can only 403.
 
 ---
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@bool/shared": "workspace:*"

--- a/packages/api/src/client.test.ts
+++ b/packages/api/src/client.test.ts
@@ -61,14 +61,29 @@ describe('apiFetch', () => {
     );
   });
 
-  it('retries on 500 errors', async () => {
+  it('does not retry on 500 errors (single-use Turnstile token is already consumed)', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: 'Server error' }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await expect(
+      apiFetch('https://api.example.com/data', { retries: 2, retryDelayMs: 1 })
+    ).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(500);
+      return true;
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on network errors', async () => {
     const mockFetch = vi
       .fn()
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        json: () => Promise.resolve({ error: 'Server error' }),
-      })
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ data: 'recovered' }),

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -11,8 +11,11 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_RETRIES = 2;
 const DEFAULT_RETRY_DELAY_MS = 1_000;
 
+// 5xx is deliberately not retryable: the Lambdas validate the single-use
+// Turnstile token before anything else, so replaying the same body after a
+// 5xx (which the token already paid for) can only produce a 403.
 function isRetryable(status: number): boolean {
-  return status === 429 || status >= 500;
+  return status === 429;
 }
 
 export async function apiFetch<T>(url: string, options: FetchOptions = {}): Promise<T> {

--- a/packages/api/src/env.d.ts
+++ b/packages/api/src/env.d.ts
@@ -1,0 +1,10 @@
+// The client reads PUBLIC_API_BASE_URL from the build-time env (injected by
+// Astro/Vite). Declare it here so this framework-agnostic package types
+// import.meta.env without pulling in astro/client or vite/client.
+interface ImportMetaEnv {
+  readonly PUBLIC_API_BASE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,5 +1,12 @@
 {
   "extends": "@bool/tsconfig/library.json",
+  "compilerOptions": {
+    // This package is consumed as raw TS (exports -> ./index.ts), never emitted,
+    // and its barrel imports use .ts extensions. Force noEmit so
+    // allowImportingTsExtensions (from base.json) is valid — otherwise the
+    // library preset's noEmit:false triggers TS5096.
+    "noEmit": true
+  },
   "include": ["src", "index.ts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
The Lambdas validate the single-use Turnstile token before anything else, so replaying the same request body after a 5xx (which already consumed the token) can only produce a 403. Retrying 5xx therefore just adds backoff latency and swaps the surfaced error class. Restrict isRetryable to 429 and network errors/timeouts, where the token is either unconsumed or the throttle happens before the Lambda runs.

Also fix pre-existing config problems in @bool/api surfaced while touching the package: it had no typecheck script (so it escaped CI type checking), its tsconfig hit TS5096 in the IDE (library preset noEmit:false vs base allowImportingTsExtensions), and import.meta.env was untyped. Add noEmit override, a package-local env.d.ts, and a typecheck script.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Testing

- [ ] Unit tests pass (`pnpm test`)
- [ ] E2E tests pass (`pnpm test:e2e`)
- [ ] Type check passes (`pnpm typecheck`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Tested locally in browser

## Screenshots

<!-- If UI changes, add before/after screenshots -->

## Notes

<!-- Anything reviewers should know -->
