### PR TITLE
refactor(ui): validate the event form with a shared Zod schema

### DIFF
--- a/documentation/security.md
+++ b/documentation/security.md
@@ -66,11 +66,12 @@ Forms attach a Turnstile token that the Lambda verifies server-side before sendi
 
 Zod schemas in `@bool/shared` (`src/validation.ts`) validate form input client-side via `react-hook-form` + `@hookform/resolvers`. The Lambda re-validates server-side — client validation is UX, not a trust boundary.
 
-| Schema                    | Key constraints                                                                                              |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `contactFormSchema`       | `firstName`/`lastName` 2–50; valid `email`; optional `phone` (`/^\+?[\d\s\-().]{7,20}$/`); `message` 10–2000 |
-| `contactFormSimpleSchema` | `name` 2–100; valid `email`; `message` 10–2000                                                               |
-| `newsletterSchema`        | `name` 2–100; valid `email`                                                                                  |
+| Schema                    | Key constraints                                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `contactFormSchema`       | `firstName`/`lastName` 2–50; valid `email`; optional `phone` (`/^\+?[\d\s\-().]{7,20}$/`); `message` 10–2000  |
+| `contactFormSimpleSchema` | `name` 2–100; valid `email`; `message` 10–2000                                                                |
+| `newsletterSchema`        | `name` 2–100; valid `email`                                                                                   |
+| `eventScheduleSchema`     | `fullName` 2–100; optional `phone` (same pattern); valid `email`; `time` required; `message` 1–5000 (API cap) |
 
 The `@bool/api` client (`src/client.ts`) sets a 15s timeout via `AbortController`, retries twice with exponential backoff on `429`/`5xx` only, and throws a typed `ApiError` otherwise.
 

--- a/packages/content/src/labels.ts
+++ b/packages/content/src/labels.ts
@@ -135,8 +135,6 @@ export function getEventScheduleLabels(locale: Locale = 'en') {
     messagePlaceholder: t('eventSchedule.messagePlaceholder', locale),
     submit: t('eventSchedule.submit', locale),
     success: t('eventSchedule.success', locale),
-    required: t('eventSchedule.required', locale),
-    emailInvalid: t('eventSchedule.emailInvalid', locale),
     captchaRequired: t('eventSchedule.captchaRequired', locale),
     error: t('eventSchedule.error', locale),
   };

--- a/packages/shared/src/validation.test.ts
+++ b/packages/shared/src/validation.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { contactFormSchema, contactFormSimpleSchema, newsletterSchema } from './validation.ts';
+import {
+  contactFormSchema,
+  contactFormSimpleSchema,
+  eventScheduleSchema,
+  newsletterSchema,
+} from './validation.ts';
 
 describe('contactFormSchema', () => {
   const valid = {
@@ -103,5 +108,60 @@ describe('newsletterSchema', () => {
 
   it('rejects missing name', () => {
     expect(newsletterSchema.safeParse({ email: 'test@example.com' }).success).toBe(false);
+  });
+});
+
+describe('eventScheduleSchema', () => {
+  const valid = {
+    fullName: 'Jane Doe',
+    phone: '+351 912 345 678',
+    email: 'jane@example.com',
+    time: 'Morning',
+    message: 'Looking forward to it.',
+  };
+
+  it('accepts valid input', () => {
+    expect(eventScheduleSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('accepts an empty phone (now optional)', () => {
+    expect(eventScheduleSchema.safeParse({ ...valid, phone: '' }).success).toBe(true);
+  });
+
+  it('accepts a missing phone', () => {
+    const { phone: _phone, ...withoutPhone } = valid;
+    expect(eventScheduleSchema.safeParse(withoutPhone).success).toBe(true);
+  });
+
+  it('rejects a malformed phone', () => {
+    expect(eventScheduleSchema.safeParse({ ...valid, phone: 'abc' }).success).toBe(false);
+  });
+
+  it('rejects short fullName', () => {
+    expect(eventScheduleSchema.safeParse({ ...valid, fullName: 'J' }).success).toBe(false);
+  });
+
+  it('rejects invalid email', () => {
+    expect(eventScheduleSchema.safeParse({ ...valid, email: 'not-an-email' }).success).toBe(false);
+  });
+
+  it('rejects empty time', () => {
+    expect(eventScheduleSchema.safeParse({ ...valid, time: '' }).success).toBe(false);
+  });
+
+  it('rejects empty message', () => {
+    expect(eventScheduleSchema.safeParse({ ...valid, message: '' }).success).toBe(false);
+  });
+
+  it('rejects message over 5000 chars', () => {
+    expect(eventScheduleSchema.safeParse({ ...valid, message: 'x'.repeat(5001) }).success).toBe(
+      false
+    );
+  });
+
+  it('accepts message at exactly 5000 chars', () => {
+    expect(eventScheduleSchema.safeParse({ ...valid, message: 'x'.repeat(5000) }).success).toBe(
+      true
+    );
   });
 });

--- a/packages/shared/src/validation.ts
+++ b/packages/shared/src/validation.ts
@@ -23,6 +23,24 @@ export const newsletterSchema = z.object({
   email: z.string().email('Invalid email address'),
 });
 
+// Validates the EventScheduleModal form fields. `message` is capped at 5000 to
+// match the /event API limit; `phone` is optional (the API no longer requires it).
+export const eventScheduleSchema = z.object({
+  fullName: z.string().min(2, 'Name must be at least 2 characters').max(100),
+  phone: z
+    .string()
+    .regex(/^\+?[\d\s\-().]{7,20}$/, 'Invalid phone number')
+    .optional()
+    .or(z.literal('')),
+  email: z.string().email('Invalid email address'),
+  time: z.string().min(1, 'Please select a time'),
+  message: z
+    .string()
+    .min(1, 'Message is required')
+    .max(5000, 'Message must be at most 5000 characters'),
+});
+
 export type ContactFormInput = z.infer<typeof contactFormSchema>;
 export type ContactFormSimpleInput = z.infer<typeof contactFormSimpleSchema>;
 export type NewsletterInput = z.infer<typeof newsletterSchema>;
+export type EventScheduleInput = z.infer<typeof eventScheduleSchema>;

--- a/packages/ui/src/compositions/EventScheduleModal/EventScheduleModal.test.tsx
+++ b/packages/ui/src/compositions/EventScheduleModal/EventScheduleModal.test.tsx
@@ -1,10 +1,12 @@
 import { cleanup, render, screen, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { submitEventSchedule } from '@bool/api';
+import { ApiError, submitEventSchedule } from '@bool/api';
 import EventScheduleModal, { type EventScheduleLabels } from './EventScheduleModal';
 
-vi.mock('@bool/api', () => ({
+// Keep the real ApiError export so the modal's `err instanceof ApiError` check works.
+vi.mock('@bool/api', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   submitEventSchedule: vi.fn(() => Promise.resolve()),
 }));
 
@@ -39,8 +41,6 @@ const labels: EventScheduleLabels = {
   messagePlaceholder: 'Any additional notes',
   submit: 'Schedule',
   success: 'Your slot has been requested!',
-  required: 'Required',
-  emailInvalid: 'Invalid email',
   captchaRequired: 'Please complete the CAPTCHA.',
   error: 'Something went wrong. Please try again.',
 };
@@ -96,7 +96,8 @@ describe('EventScheduleModal', () => {
     await user.click(screen.getByRole('button', { name: 'Schedule' }));
 
     await waitFor(() => {
-      expect(screen.getAllByText('Required').length).toBeGreaterThan(0);
+      expect(screen.getByText('Name must be at least 2 characters')).toBeInTheDocument();
+      expect(screen.getByText('Message is required')).toBeInTheDocument();
     });
   });
 
@@ -109,7 +110,7 @@ describe('EventScheduleModal', () => {
     await user.click(screen.getByRole('button', { name: 'Schedule' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Invalid email')).toBeInTheDocument();
+      expect(screen.getByText('Invalid email address')).toBeInTheDocument();
     });
   });
 
@@ -139,6 +140,63 @@ describe('EventScheduleModal', () => {
       message: 'Looking forward to it.',
       turnstileToken: '',
     });
+  });
+
+  it('submits successfully without a phone (now optional)', async () => {
+    const user = userEvent.setup();
+    render(<EventScheduleModal labels={labels} captchaSiteKey="" />);
+    openModal('OutSystems NextStep 2026');
+
+    await user.type(screen.getByLabelText('Full Name'), 'Jane Doe');
+    await user.type(screen.getByLabelText('Email'), 'jane@example.com');
+    await user.selectOptions(screen.getByLabelText('Preferred time'), '11:00');
+    await user.type(screen.getByLabelText('Message'), 'Looking forward to it.');
+
+    await user.click(screen.getByRole('button', { name: 'Schedule' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Your slot has been requested!')).toBeInTheDocument();
+    });
+    expect(submitEventSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Jane Doe', phone: '' })
+    );
+  });
+
+  it('maps a 403 to the captcha message instead of the generic error', async () => {
+    vi.mocked(submitEventSchedule).mockRejectedValueOnce(
+      new ApiError(403, { error: 'CAPTCHA validation failed. Please try again.' })
+    );
+    const user = userEvent.setup();
+    render(<EventScheduleModal labels={labels} captchaSiteKey="" />);
+    openModal('OutSystems NextStep 2026');
+
+    await user.type(screen.getByLabelText('Full Name'), 'Jane Doe');
+    await user.type(screen.getByLabelText('Email'), 'jane@example.com');
+    await user.selectOptions(screen.getByLabelText('Preferred time'), '11:00');
+    await user.type(screen.getByLabelText('Message'), 'Looking forward to it.');
+
+    await user.click(screen.getByRole('button', { name: 'Schedule' }));
+
+    expect(await screen.findByText('Please complete the CAPTCHA.')).toBeInTheDocument();
+    expect(screen.queryByText('Something went wrong. Please try again.')).not.toBeInTheDocument();
+  });
+
+  it('does not submit when opened without an event name', async () => {
+    const user = userEvent.setup();
+    render(<EventScheduleModal labels={labels} captchaSiteKey="" />);
+    act(() => {
+      window.dispatchEvent(new CustomEvent('bool:open-event-schedule', { detail: {} }));
+    });
+
+    await user.type(screen.getByLabelText('Full Name'), 'Jane Doe');
+    await user.type(screen.getByLabelText('Email'), 'jane@example.com');
+    await user.selectOptions(screen.getByLabelText('Preferred time'), '11:00');
+    await user.type(screen.getByLabelText('Message'), 'Looking forward to it.');
+
+    await user.click(screen.getByRole('button', { name: 'Schedule' }));
+
+    expect(await screen.findByText('Something went wrong. Please try again.')).toBeInTheDocument();
+    expect(submitEventSchedule).not.toHaveBeenCalled();
   });
 
   it('closes when the X button is clicked', async () => {

--- a/packages/ui/src/compositions/EventScheduleModal/EventScheduleModal.tsx
+++ b/packages/ui/src/compositions/EventScheduleModal/EventScheduleModal.tsx
@@ -1,9 +1,11 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { CheckCircle, ChevronDown, X } from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { trackEvent } from '@bool/analytics';
-import { submitEventSchedule } from '@bool/api';
+import { ApiError, submitEventSchedule } from '@bool/api';
+import { eventScheduleSchema, type EventScheduleInput } from '@bool/shared';
 import Captcha from '../Captcha/Captcha';
 import type { CaptchaHandle } from '../Captcha/Captcha';
 import styles from './EventScheduleModal.module.css';
@@ -26,26 +28,14 @@ export interface EventScheduleLabels {
   messagePlaceholder: string;
   submit: string;
   success: string;
-  required: string;
-  emailInvalid: string;
   captchaRequired: string;
   error: string;
-}
-
-interface FormFields {
-  fullName: string;
-  phone: string;
-  email: string;
-  time: string;
-  message: string;
 }
 
 /** Event detail dispatched by the "Meet us there" triggers in EventsSection. */
 interface OpenEventDetail {
   title?: string;
 }
-
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 interface Props {
   labels: EventScheduleLabels;
@@ -66,7 +56,7 @@ export default function EventScheduleModal({ labels, captchaSiteKey }: Props) {
     reset,
     setError,
     formState: { errors, isSubmitting },
-  } = useForm<FormFields>();
+  } = useForm<EventScheduleInput>({ resolver: zodResolver(eventScheduleSchema) });
 
   useEffect(() => {
     function handleOpen(event: Event) {
@@ -82,7 +72,14 @@ export default function EventScheduleModal({ labels, captchaSiteKey }: Props) {
     return () => window.removeEventListener('bool:open-event-schedule', handleOpen);
   }, [reset]);
 
-  async function onSubmit(data: FormFields) {
+  async function onSubmit(data: EventScheduleInput) {
+    // The event name comes from the trigger's dispatched detail; guard against a
+    // trigger that opened the modal without one (would POST an empty event_name).
+    if (!eventTitle) {
+      setError('root', { message: labels.error });
+      return;
+    }
+
     let token = captchaToken;
     if (captchaSiteKey && !token) {
       token = (await captchaRef.current?.execute()) ?? '';
@@ -97,7 +94,7 @@ export default function EventScheduleModal({ labels, captchaSiteKey }: Props) {
       await submitEventSchedule({
         eventName: eventTitle,
         name: data.fullName,
-        phone: data.phone,
+        phone: data.phone ?? '',
         email: data.email,
         timeSuggestion: data.time,
         message: data.message,
@@ -105,8 +102,12 @@ export default function EventScheduleModal({ labels, captchaSiteKey }: Props) {
       });
       trackEvent('form_submission', { type: 'event' });
       setSubmitted(true);
-    } catch {
-      setError('root', { message: labels.error });
+    } catch (err) {
+      // Token is single-use and now spent; reset the widget. A 403 is a failed
+      // token validation, so surface the captcha label rather than the generic error.
+      const message =
+        err instanceof ApiError && err.status === 403 ? labels.captchaRequired : labels.error;
+      setError('root', { message });
       setCaptchaToken('');
       captchaRef.current?.reset();
     }
@@ -172,7 +173,7 @@ export default function EventScheduleModal({ labels, captchaSiteKey }: Props) {
                     autoComplete="name"
                     placeholder={labels.fullNamePlaceholder}
                     className={styles.input}
-                    {...register('fullName', { required: labels.required })}
+                    {...register('fullName')}
                   />
                   {errors.fullName && (
                     <p className={styles.fieldError}>{errors.fullName.message}</p>
@@ -191,6 +192,7 @@ export default function EventScheduleModal({ labels, captchaSiteKey }: Props) {
                     className={styles.input}
                     {...register('phone')}
                   />
+                  {errors.phone && <p className={styles.fieldError}>{errors.phone.message}</p>}
                 </div>
               </div>
 
@@ -205,10 +207,7 @@ export default function EventScheduleModal({ labels, captchaSiteKey }: Props) {
                     autoComplete="email"
                     placeholder={labels.emailPlaceholder}
                     className={styles.input}
-                    {...register('email', {
-                      required: labels.required,
-                      pattern: { value: EMAIL_PATTERN, message: labels.emailInvalid },
-                    })}
+                    {...register('email')}
                   />
                   {errors.email && <p className={styles.fieldError}>{errors.email.message}</p>}
                 </div>
@@ -222,7 +221,7 @@ export default function EventScheduleModal({ labels, captchaSiteKey }: Props) {
                       id={`${formId}-time`}
                       defaultValue=""
                       className={styles.select}
-                      {...register('time', { required: labels.required })}
+                      {...register('time')}
                     >
                       <option value="" disabled>
                         {labels.timePlaceholder}
@@ -248,7 +247,7 @@ export default function EventScheduleModal({ labels, captchaSiteKey }: Props) {
                   rows={4}
                   placeholder={labels.messagePlaceholder}
                   className={styles.textarea}
-                  {...register('message', { required: labels.required })}
+                  {...register('message')}
                 />
                 {errors.message && <p className={styles.fieldError}>{errors.message.message}</p>}
               </div>


### PR DESCRIPTION
The EventScheduleModal was the one form outside the @bool/shared Zod architecture — it used ad-hoc react-hook-form rules and a hand-rolled email regex, and as a result had no message-length cap and could POST an empty event_name. Add eventScheduleSchema (phone optional to match the API, message capped at the 5000-char API limit) and drive the modal with zodResolver like ContactForm.

Also guard against submitting an empty event_name (a trigger that opened the modal without a title), map a 403 to the captcha label, and drop the now-unused `required`/`emailInvalid` labels from the component and label builder. The matching orphaned eventSchedule.required/emailInvalid keys remain in en.json (Drive-synced source) for a follow-up cleanup there.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Testing

- [ ] Unit tests pass (`pnpm test`)
- [ ] E2E tests pass (`pnpm test:e2e`)
- [ ] Type check passes (`pnpm typecheck`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Tested locally in browser

## Screenshots

<!-- If UI changes, add before/after screenshots -->

## Notes

<!-- Anything reviewers should know -->
