### PR TITLE
chore(web): fail CI build on missing form env; pin CSP to API origin

### DIFF
--- a/apps/web/bool/astro.config.ts
+++ b/apps/web/bool/astro.config.ts
@@ -13,6 +13,22 @@ import { baseViteConfig } from '@bool/vite-config/base';
 // site that loads no analytics. Read from process.env (set in CI) at config time.
 const gaEnabled = Boolean(process.env.PUBLIC_GA_MEASUREMENT_ID);
 
+// Fail the deploy loudly if the public form-config vars are missing. Without
+// them the site builds fine but every form POSTs to an empty URL / with an
+// empty Turnstile token and silently 400/403s in production. A missing GitHub
+// repo variable arrives as an empty string, so check for falsy, not undefined.
+// Only enforced in CI — locally these stay optional so `pnpm dev` works without
+// them (posts from localhost are CORS-blocked by the API anyway).
+if (process.env.CI) {
+  for (const name of ['PUBLIC_API_BASE_URL', 'PUBLIC_TURNSTILE_SITE_KEY'] as const) {
+    if (!process.env[name]) {
+      throw new Error(
+        `Missing required build variable ${name}. Set it in the GitHub repo variables (see documentation/ci-deploy.md).`
+      );
+    }
+  }
+}
+
 export default defineConfig({
   site: SITE_URL,
   base: '/bool/',

--- a/documentation/ci-deploy.md
+++ b/documentation/ci-deploy.md
@@ -31,12 +31,12 @@ All configuration lives in GitHub — no `.env.local` files needed. Configure at
 
 ### Variables (`vars.*`) — non-sensitive, visible in logs
 
-| Variable                    | Used by                | Description                                                              |
-| --------------------------- | ---------------------- | ------------------------------------------------------------------------ |
-| `PUBLIC_API_BASE_URL`       | CI, Deploy, Lighthouse | Form API base URL; paths `/contact`, `/subscribe`, `/event` are appended |
-| `PUBLIC_TURNSTILE_SITE_KEY` | CI, Deploy, Lighthouse | Cloudflare Turnstile site key (public, identifies site)                  |
-| `PUBLIC_GA_MEASUREMENT_ID`  | CI, Deploy, Lighthouse | Google Analytics 4 measurement ID                                        |
-| `PUBLIC_SENTRY_DSN`         | CI, Deploy             | Sentry DSN for error monitoring                                          |
+| Variable                    | Used by                | Description                                                                                                            |
+| --------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `PUBLIC_API_BASE_URL`       | CI, Deploy, Lighthouse | Form API base URL; paths `/contact`, `/subscribe`, `/event` are appended. Build-required — a CI build throws if unset. |
+| `PUBLIC_TURNSTILE_SITE_KEY` | CI, Deploy, Lighthouse | Cloudflare Turnstile site key (public, identifies site). Build-required — a CI build throws if unset.                  |
+| `PUBLIC_GA_MEASUREMENT_ID`  | CI, Deploy, Lighthouse | Google Analytics 4 measurement ID                                                                                      |
+| `PUBLIC_SENTRY_DSN`         | CI, Deploy             | Sentry DSN for error monitoring                                                                                        |
 
 ### Secrets (`secrets.*`) — encrypted, masked in logs
 

--- a/documentation/security.md
+++ b/documentation/security.md
@@ -21,21 +21,23 @@ Emitted:
 
 ### CSP directives
 
-| Directive     | Sources                                                                                                                  | Why                                    |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
-| `default-src` | `'self'`                                                                                                                 | deny by default                        |
-| `script-src`  | `'self' 'unsafe-inline' challenges.cloudflare.com googletagmanager.com`                                                  | Astro island hydration, Turnstile, GTM |
-| `style-src`   | `'self' 'unsafe-inline'`                                                                                                 | Tailwind + Astro scoped styles         |
-| `frame-src`   | `'self' challenges.cloudflare.com`                                                                                       | Turnstile challenge iframe             |
-| `worker-src`  | `'self' blob:`                                                                                                           | Partytown GA4 worker                   |
-| `img-src`     | `'self' data: www.google-analytics.com`                                                                                  | inline data URIs, GA pixels            |
-| `connect-src` | `'self' challenges.cloudflare.com *.amazonaws.com www.google-analytics.com analytics.google.com stats.g.doubleclick.net` | form API (AWS), Turnstile, GA          |
-| `font-src`    | `'self'`                                                                                                                 | self-hosted WOFF2 only                 |
-| `object-src`  | `'none'`                                                                                                                 | no plugins                             |
-| `base-uri`    | `'self'`                                                                                                                 | block `<base>` injection               |
-| `form-action` | `'self'`                                                                                                                 | block off-origin native form posts     |
+| Directive     | Sources                                                                                                                               | Why                                    |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `default-src` | `'self'`                                                                                                                              | deny by default                        |
+| `script-src`  | `'self' 'unsafe-inline' challenges.cloudflare.com googletagmanager.com`                                                               | Astro island hydration, Turnstile, GTM |
+| `style-src`   | `'self' 'unsafe-inline'`                                                                                                              | Tailwind + Astro scoped styles         |
+| `frame-src`   | `'self' challenges.cloudflare.com`                                                                                                    | Turnstile challenge iframe             |
+| `worker-src`  | `'self' blob:`                                                                                                                        | Partytown GA4 worker                   |
+| `img-src`     | `'self' data: www.google-analytics.com`                                                                                               | inline data URIs, GA pixels            |
+| `connect-src` | `'self' challenges.cloudflare.com <PUBLIC_API_BASE_URL origin> www.google-analytics.com analytics.google.com stats.g.doubleclick.net` | form API (exact origin), Turnstile, GA |
+| `font-src`    | `'self'`                                                                                                                              | self-hosted WOFF2 only                 |
+| `object-src`  | `'none'`                                                                                                                              | no plugins                             |
+| `base-uri`    | `'self'`                                                                                                                              | block `<base>` injection               |
+| `form-action` | `'self'`                                                                                                                              | block off-origin native form posts     |
 
 `'unsafe-inline'` on `script-src`/`style-src` is required by Astro's hydration and scoped-style model; tightening it would mean a nonce/hash strategy the static build doesn't currently emit. If you add a third-party origin (a new analytics or embed), it must be added to the matching directive or the browser blocks it.
+
+`connect-src` is pinned to the exact form-API origin derived from `PUBLIC_API_BASE_URL` (not a broad `*.amazonaws.com`), so a compromised inline script can only reach the one endpoint the site actually uses. Because the origin is build-time config, `astro.config.ts` throws in CI if `PUBLIC_API_BASE_URL` or `PUBLIC_TURNSTILE_SITE_KEY` is missing — a missing key would otherwise ship a site whose forms silently fail.
 
 `SEOHead.astro` also renders `<meta name="robots" content="noindex, nofollow">` when a page passes `noindex` (used for legal/utility pages).
 

--- a/packages/seo/src/SecurityHeaders.astro
+++ b/packages/seo/src/SecurityHeaders.astro
@@ -3,12 +3,18 @@
 // Note: frame-ancestors and X-Frame-Options cannot be enforced via meta tags — browsers
 // require those as HTTP response headers. Framing protection requires a CDN (e.g. Cloudflare)
 // in front of GitHub Pages if it becomes a requirement.
-// The form API (API Gateway + Lambda) is reached over https://*.amazonaws.com (connect-src).
+// The form API (API Gateway + Lambda) is reached over its exact origin, pinned
+// in connect-src from PUBLIC_API_BASE_URL (empty in local dev, where no API call runs).
 // Cloudflare Turnstile loads its script and challenge iframe from challenges.cloudflare.com.
 // The policy itself (incl. conditional GA domains) is built by buildContentSecurityPolicy.
 import { buildContentSecurityPolicy } from './csp';
 
-const csp = buildContentSecurityPolicy(Boolean(import.meta.env.PUBLIC_GA_MEASUREMENT_ID));
+const apiBaseUrl = import.meta.env.PUBLIC_API_BASE_URL;
+const apiOrigin = apiBaseUrl ? new URL(apiBaseUrl).origin : '';
+const csp = buildContentSecurityPolicy(
+  Boolean(import.meta.env.PUBLIC_GA_MEASUREMENT_ID),
+  apiOrigin
+);
 ---
 
 <meta http-equiv="Content-Security-Policy" content={csp} />

--- a/packages/seo/src/csp.test.ts
+++ b/packages/seo/src/csp.test.ts
@@ -8,29 +8,47 @@ const GOOGLE_DOMAINS = [
   'stats.g.doubleclick.net',
 ];
 
+const API_ORIGIN = 'https://upci9flznj.execute-api.eu-west-3.amazonaws.com';
+
 describe('buildContentSecurityPolicy', () => {
   it('omits all Google Analytics domains when GA is disabled (BOOL-08)', () => {
-    const csp = buildContentSecurityPolicy(false);
+    const csp = buildContentSecurityPolicy(false, API_ORIGIN);
     for (const domain of GOOGLE_DOMAINS) {
       expect(csp).not.toContain(domain);
     }
   });
 
   it('includes the Google Analytics domains when GA is enabled', () => {
-    const csp = buildContentSecurityPolicy(true);
+    const csp = buildContentSecurityPolicy(true, API_ORIGIN);
     for (const domain of GOOGLE_DOMAINS) {
       expect(csp).toContain(domain);
     }
   });
 
+  it('pins connect-src to the exact API origin, not all of *.amazonaws.com', () => {
+    const csp = buildContentSecurityPolicy(false, API_ORIGIN);
+    expect(csp).toContain(API_ORIGIN);
+    expect(csp).not.toContain('*.amazonaws.com');
+  });
+
+  it('omits the API origin when none is provided (local dev)', () => {
+    const csp = buildContentSecurityPolicy(false, '');
+    expect(csp).not.toContain('amazonaws.com');
+    // connect-src still exists with self + Turnstile.
+    expect(csp).toContain("connect-src 'self' https://challenges.cloudflare.com");
+  });
+
   it('always keeps the core hardening directives regardless of GA', () => {
-    for (const csp of [buildContentSecurityPolicy(false), buildContentSecurityPolicy(true)]) {
+    for (const csp of [
+      buildContentSecurityPolicy(false, API_ORIGIN),
+      buildContentSecurityPolicy(true, API_ORIGIN),
+    ]) {
       expect(csp).toContain("default-src 'self'");
       expect(csp).toContain("object-src 'none'");
       expect(csp).toContain("base-uri 'self'");
       expect(csp).toContain("form-action 'self'");
       // Form API + Turnstile must always be reachable.
-      expect(csp).toContain('https://*.amazonaws.com');
+      expect(csp).toContain(API_ORIGIN);
       expect(csp).toContain('https://challenges.cloudflare.com');
       expect(csp.endsWith(';')).toBe(true);
     }

--- a/packages/seo/src/csp.ts
+++ b/packages/seo/src/csp.ts
@@ -5,14 +5,19 @@
  * when GA is configured, so a deployment without `PUBLIC_GA_MEASUREMENT_ID` never
  * widens `script-src`/`img-src`/`connect-src` to Google endpoints it cannot use.
  *
+ * `apiOrigin` is the exact form-API origin (from `PUBLIC_API_BASE_URL`) so
+ * `connect-src` is pinned to that host rather than all of `*.amazonaws.com`.
+ * It is empty only in local dev (the var is unset), where no API call is made.
+ *
  * Note: `frame-ancestors`/`X-Frame-Options` are intentionally absent — browsers
  * only honour those as real HTTP response headers, not meta tags, so framing
  * protection must be set at the CDN/edge in production.
  */
-export function buildContentSecurityPolicy(gaEnabled: boolean): string {
+export function buildContentSecurityPolicy(gaEnabled: boolean, apiOrigin: string): string {
   const scriptSrc = ["'self'", "'unsafe-inline'", 'https://challenges.cloudflare.com'];
   const imgSrc = ["'self'", 'data:'];
-  const connectSrc = ["'self'", 'https://challenges.cloudflare.com', 'https://*.amazonaws.com'];
+  const connectSrc = ["'self'", 'https://challenges.cloudflare.com'];
+  if (apiOrigin) connectSrc.push(apiOrigin);
 
   if (gaEnabled) {
     scriptSrc.push('https://www.googletagmanager.com');


### PR DESCRIPTION
Two forms-security hardening changes:

1. astro.config.ts throws in CI when PUBLIC_API_BASE_URL or PUBLIC_TURNSTILE_SITE_KEY is missing. A missing GitHub repo variable arrives as an empty string and previously shipped a site whose forms POST to an empty URL / with an empty Turnstile token and silently fail. The check is CI-only so local `pnpm dev` still works without the vars (localhost posts are CORS-blocked by the API regardless).

2. connect-src is pinned to the exact PUBLIC_API_BASE_URL origin instead of the whole *.amazonaws.com wildcard, so a compromised inline script can only reach the one endpoint the site uses. The origin is derived at build time in SecurityHeaders.astro; it is empty in local dev, where no API call is made.

Verified with a real astro build both ways: the guard throws without the vars, and with them set the emitted CSP contains only the exact origin.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Testing

- [ ] Unit tests pass (`pnpm test`)
- [ ] E2E tests pass (`pnpm test:e2e`)
- [ ] Type check passes (`pnpm typecheck`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Tested locally in browser

## Screenshots

<!-- If UI changes, add before/after screenshots -->

## Notes

<!-- Anything reviewers should know -->
