### PR TITLE
fix(web): scope the missing-env guard to `astro build` only (fixes master CI)

### DIFF
--- a/apps/web/bool/astro.config.ts
+++ b/apps/web/bool/astro.config.ts
@@ -17,9 +17,12 @@ const gaEnabled = Boolean(process.env.PUBLIC_GA_MEASUREMENT_ID);
 // them the site builds fine but every form POSTs to an empty URL / with an
 // empty Turnstile token and silently 400/403s in production. A missing GitHub
 // repo variable arrives as an empty string, so check for falsy, not undefined.
-// Only enforced in CI — locally these stay optional so `pnpm dev` works without
-// them (posts from localhost are CORS-blocked by the API anyway).
-if (process.env.CI) {
+// Scoped to `astro build` in CI: the config also loads for `astro check`
+// (typecheck) and `astro preview` (e2e serves the pre-built dist), and neither
+// of those is given the vars. Locally the vars stay optional so `pnpm dev`/`pnpm
+// build` work without them (posts from localhost are CORS-blocked anyway).
+const isProductionBuild = process.env.CI && process.argv.includes('build');
+if (isProductionBuild) {
   for (const name of ['PUBLIC_API_BASE_URL', 'PUBLIC_TURNSTILE_SITE_KEY'] as const) {
     if (!process.env[name]) {
       throw new Error(


### PR DESCRIPTION
## What

Scopes the CI env-var guard in `astro.config.ts` to `astro build` only (`process.env.CI && process.argv.includes('build')`).

## Why

The guard merged in #21 fired on **every** Astro command, not just the production build. `astro check` (the verify job's typecheck) and `astro preview` (the e2e job, which serves the already-built `dist`) both load the config without the form env vars set, so the guard threw and **both jobs fail on `master` right now**.

With this fix the build/deploy still fail loudly if `PUBLIC_API_BASE_URL` / `PUBLIC_TURNSTILE_SITE_KEY` is missing, while check/preview/dev run without them.

## Verification

Reproduced each CI command locally under `CI=true` with no vars: `astro check` passes, `astro build` throws the missing-var error, and `astro build` with the vars set completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
