### PR TITLE
chore: harden CI workflows, escape JSON-LD, and gate consent by version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "group:monorepos", "group:recommended"],
+  "extends": [
+    "config:recommended",
+    "group:monorepos",
+    "group:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "description": "Group Astro packages",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: the jobs only read the repo, build, and up/download artifacts
+# within the same run — none of which needs a writable token.
+permissions:
+  contents: read
+
 env:
   # Run JS actions (incl. ones bundled transitively, e.g. inside
   # upload-pages-artifact) on Node 24 — silences the Node 20 deprecation
@@ -23,15 +28,15 @@ jobs:
     name: Lint · Typecheck · Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Cache Turbo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.sha }}
@@ -42,7 +47,7 @@ jobs:
         run: pnpm knip
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: coverage
           path: packages/*/coverage/
@@ -55,15 +60,15 @@ jobs:
     # verify still blocks the PR independently.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Cache Turbo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.sha }}
@@ -71,7 +76,7 @@ jobs:
       # Persist Astro's sharp image-optimization cache so unchanged images
       # aren't re-encoded every run (the case-study set is large).
       - name: Cache Astro image optimization
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: apps/web/bool/node_modules/.astro
           key: astro-cache-${{ runner.os }}-${{ github.sha }}
@@ -89,7 +94,7 @@ jobs:
           cp -r apps/web/json-editor/dist apps/web/bool/dist/json-editor
       # Reused by the e2e job so it doesn't rebuild the whole site from scratch.
       - name: Upload built site
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: site-dist
           path: apps/web/bool/dist
@@ -101,22 +106,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       # Reuse the build job's output instead of rebuilding (astro preview serves dist).
       - name: Download built site
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: site-dist
           path: apps/web/bool/dist
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -130,7 +135,7 @@ jobs:
         run: pnpm test:e2e
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,26 +21,29 @@ env:
 jobs:
   build-and-deploy:
     name: Build & Deploy
+    # workflow_dispatch can be launched against any branch that contains this
+    # file; restrict the actual Pages publish to the canonical production branch.
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Cache Turbo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.sha }}
           restore-keys: turbo-${{ runner.os }}-
       - name: Cache Astro image optimization
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: apps/web/bool/node_modules/.astro
           key: astro-cache-${{ runner.os }}-${{ github.sha }}
@@ -56,8 +59,8 @@ jobs:
         run: |
           test -d apps/web/json-editor/dist || { echo "::error::json-editor build output missing — aborting merge"; exit 1; }
           cp -r apps/web/json-editor/dist apps/web/bool/dist/json-editor
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: apps/web/bool/dist
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -8,14 +8,18 @@ concurrency:
   group: lighthouse-${{ github.ref }}
   cancel-in-progress: true
 
+# Runs on pull_request and only reads the repo to build + audit.
+permissions:
+  contents: read
+
 jobs:
   lighthouse:
     name: Lighthouse Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: pnpm
@@ -23,14 +27,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Cache Turbo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.sha }}
           restore-keys: turbo-${{ runner.os }}-
 
       - name: Cache Astro image optimization
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: apps/web/bool/node_modules/.astro
           key: astro-cache-${{ runner.os }}-${{ github.sha }}
@@ -44,7 +48,7 @@ jobs:
           PUBLIC_GA_MEASUREMENT_ID: ${{ vars.PUBLIC_GA_MEASUREMENT_ID }}
 
       - name: Run Lighthouse
-        uses: treosh/lighthouse-ci-action@v12
+        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
         with:
           configPath: tooling/lighthouse/.lighthouserc.json
           uploadArtifacts: true

--- a/.github/workflows/sync-drive.yml
+++ b/.github/workflows/sync-drive.yml
@@ -16,11 +16,11 @@ jobs:
     name: Sync Drive → media + locales
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: pnpm
@@ -35,7 +35,7 @@ jobs:
           GOOGLE_DRIVE_FOLDER_ID: ${{ vars.GOOGLE_DRIVE_FOLDER_ID || secrets.GOOGLE_DRIVE_FOLDER_ID }}
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           commit-message: 'chore(media): sync media and locales from Google Drive'
           title: 'chore(media): sync media and locales from Google Drive'

--- a/.github/workflows/test-drive-connection.yml
+++ b/.github/workflows/test-drive-connection.yml
@@ -3,16 +3,19 @@ name: Test Google Drive Connection
 on:
   workflow_dispatch:
 
+# Only reads from Google Drive and writes the step summary — no repo token scope needed.
+permissions: {}
+
 jobs:
   test:
     name: Test Drive connection
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: pnpm

--- a/apps/web/bool/astro.config.ts
+++ b/apps/web/bool/astro.config.ts
@@ -13,20 +13,23 @@ import { baseViteConfig } from '@bool/vite-config/base';
 // site that loads no analytics. Read from process.env (set in CI) at config time.
 const gaEnabled = Boolean(process.env.PUBLIC_GA_MEASUREMENT_ID);
 
-// Fail the deploy loudly if the public form-config vars are missing. Without
-// them the site builds fine but every form POSTs to an empty URL / with an
-// empty Turnstile token and silently 400/403s in production. A missing GitHub
-// repo variable arrives as an empty string, so check for falsy, not undefined.
-// Scoped to `astro build` in CI: the config also loads for `astro check`
-// (typecheck) and `astro preview` (e2e serves the pre-built dist), and neither
-// of those is given the vars. Locally the vars stay optional so `pnpm dev`/`pnpm
-// build` work without them (posts from localhost are CORS-blocked anyway).
-const isProductionBuild = process.env.CI && process.argv.includes('build');
-if (isProductionBuild) {
+// Fail the build loudly if the public form-config vars are missing. Without them
+// the site builds fine but every form POSTs to an empty URL / with an empty
+// Turnstile token and silently 400/403s in production. A missing GitHub repo
+// variable arrives as an empty string, so check for falsy, not undefined.
+// Scoped to `astro build`: the config also loads for `astro check` (typecheck)
+// and `astro preview` (e2e serves the pre-built dist), neither of which is given
+// the vars. This fires for ANY build (not just CI) so a manual production build
+// can't silently ship broken forms; set SKIP_ENV_VALIDATION=1 for a deliberate
+// local build without them (posts from localhost are CORS-blocked anyway).
+const isBuild = process.argv.includes('build');
+const skipEnvValidation = process.env.SKIP_ENV_VALIDATION === '1';
+if (isBuild && !skipEnvValidation) {
   for (const name of ['PUBLIC_API_BASE_URL', 'PUBLIC_TURNSTILE_SITE_KEY'] as const) {
     if (!process.env[name]) {
       throw new Error(
-        `Missing required build variable ${name}. Set it in the GitHub repo variables (see documentation/ci-deploy.md).`
+        `Missing required build variable ${name}. Set it in the GitHub repo variables ` +
+          `(see documentation/ci-deploy.md), or set SKIP_ENV_VALIDATION=1 for a local build without it.`
       );
     }
   }

--- a/apps/web/bool/src/pages/blog/[slug].astro
+++ b/apps/web/bool/src/pages/blog/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 import { getCollection, render } from 'astro:content';
-import { blogPostingJsonLd } from '@bool/seo';
+import { blogPostingJsonLd, serializeJsonLd } from '@bool/seo';
 import { SITE_URL, BASE_PATH } from '@bool/shared';
 import BaseLayout from '@bool/ui/layout/BaseLayout.astro';
 import { getHeaderLabels, getFooterLabels } from '../../labels';
@@ -35,7 +35,7 @@ const jsonLd = blogPostingJsonLd({
   headerLabels={getHeaderLabels()}
   footerLabels={getFooterLabels()}
 >
-  <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+  <script is:inline type="application/ld+json" set:html={serializeJsonLd(jsonLd)} />
   <article>
     <Content />
   </article>

--- a/packages/analytics/src/GoogleAnalytics.astro
+++ b/packages/analytics/src/GoogleAnalytics.astro
@@ -1,5 +1,5 @@
 ---
-import { CONSENT_STORAGE_KEY, CONSENT_ENABLED } from '@bool/compliance';
+import { CONSENT_STORAGE_KEY, CONSENT_VERSION, CONSENT_ENABLED } from '@bool/compliance';
 import { GA_MEASUREMENT_ID } from './config';
 
 // GA4 via Partytown — runs off main thread.
@@ -17,7 +17,7 @@ import { GA_MEASUREMENT_ID } from './config';
   <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
   <link rel="preconnect" href="https://www.google-analytics.com" crossorigin />
   <script
-    define:vars={{ GA_MEASUREMENT_ID, CONSENT_STORAGE_KEY }}
+    define:vars={{ GA_MEASUREMENT_ID, CONSENT_STORAGE_KEY, CONSENT_VERSION }}
   >
     (function () {
       function hasAnalyticsConsent() {
@@ -25,7 +25,9 @@ import { GA_MEASUREMENT_ID } from './config';
           var stored = localStorage.getItem(CONSENT_STORAGE_KEY);
           if (!stored) return false;
           var consent = JSON.parse(stored);
-          return consent && consent.analytics === true;
+          // Mirror getConsent(): a version mismatch counts as "no decision", so a
+          // stale record can't silently re-enable analytics after the policy changes.
+          return !!consent && consent.analytics === true && consent.version === CONSENT_VERSION;
         } catch {
           return false;
         }

--- a/packages/analytics/src/sentry.test.ts
+++ b/packages/analytics/src/sentry.test.ts
@@ -98,3 +98,29 @@ describe('setUser', () => {
     expect(mockSetUser).not.toHaveBeenCalled();
   });
 });
+
+describe('beforeSend PII scrubbing', () => {
+  it('does not send default PII', async () => {
+    await initSentry('https://key@sentry.io/123');
+    expect(mockInit.mock.calls[0]?.[0]?.sendDefaultPii).toBe(false);
+  });
+
+  it('redacts emails from exceptions/breadcrumbs and drops cookies', async () => {
+    await initSentry('https://key@sentry.io/123');
+    const beforeSend = mockInit.mock.calls[0]?.[0]?.beforeSend;
+    expect(beforeSend).toBeTypeOf('function');
+
+    const scrubbed = beforeSend(
+      {
+        request: { cookies: 'session=abc' },
+        exception: { values: [{ value: 'Failed for jane.doe@example.com!' }] },
+        breadcrumbs: [{ message: 'contact form from john@bool.pt' }],
+      },
+      {}
+    );
+
+    expect(scrubbed.request.cookies).toBeUndefined();
+    expect(scrubbed.exception.values[0].value).toBe('Failed for [redacted-email]!');
+    expect(scrubbed.breadcrumbs[0].message).toBe('contact form from [redacted-email]');
+  });
+});

--- a/packages/analytics/src/sentry.ts
+++ b/packages/analytics/src/sentry.ts
@@ -2,6 +2,13 @@ import type { BrowserOptions } from '@sentry/react';
 
 let initialized = false;
 
+const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+
+/** Redact email addresses from free-text before an event leaves the browser. */
+function redactEmails(text: string): string {
+  return text.replace(EMAIL_RE, '[redacted-email]');
+}
+
 export async function initSentry(dsn: string, options?: Partial<BrowserOptions>): Promise<void> {
   if (initialized || !dsn || typeof window === 'undefined') return;
 
@@ -25,6 +32,21 @@ export async function initSentry(dsn: string, options?: Partial<BrowserOptions>)
         blockAllMedia: true,
       }),
     ],
+    // Never attach cookies/headers/IP to events.
+    sendDefaultPii: false,
+    // Defense-in-depth PII scrubbing on the error-payload path (replays already
+    // mask text/inputs): the site runs contact/newsletter forms, so redact any
+    // email addresses that reach exception messages or breadcrumbs, and drop cookies.
+    beforeSend(event) {
+      if (event.request?.cookies) delete event.request.cookies;
+      for (const exception of event.exception?.values ?? []) {
+        if (exception.value) exception.value = redactEmails(exception.value);
+      }
+      for (const breadcrumb of event.breadcrumbs ?? []) {
+        if (breadcrumb.message) breadcrumb.message = redactEmails(breadcrumb.message);
+      }
+      return event;
+    },
     ...options,
   });
 

--- a/packages/compliance/index.ts
+++ b/packages/compliance/index.ts
@@ -1,5 +1,10 @@
 export { CookieBanner, CookiePreferencesButton } from './src/CookieBanner.tsx';
 export { getConsent, setConsent, clearConsent, isConsentExpired } from './src/consent.ts';
 export { useConsent } from './src/hooks.ts';
-export { CONSENT_ENABLED, CONSENT_STORAGE_KEY, CONSENT_CATEGORIES } from './src/config.ts';
+export {
+  CONSENT_ENABLED,
+  CONSENT_STORAGE_KEY,
+  CONSENT_VERSION,
+  CONSENT_CATEGORIES,
+} from './src/config.ts';
 export type { ConsentCategory } from './src/config.ts';

--- a/packages/media/scripts/sync-google-drive.mjs
+++ b/packages/media/scripts/sync-google-drive.mjs
@@ -62,7 +62,7 @@
  *   --delete     Remove local files not present in Drive (media only)
  */
 
-import { createSign } from 'node:crypto';
+import { createSign, randomUUID } from 'node:crypto';
 import {
   readFileSync,
   writeFileSync,
@@ -858,12 +858,16 @@ if (block) {
   }
   // 2) PR body — exposed as a multiline step output named "warnings"
   if (process.env.GITHUB_OUTPUT) {
-    const delim = 'SYNC_WARNINGS_EOF';
+    // Unguessable per-run delimiter: `block` is built from Drive-controlled file
+    // names and locale strings, so a fixed delimiter could be closed early by a
+    // matching line and inject extra step outputs into the PR body.
+    const delim = `SYNC_WARNINGS_EOF_${randomUUID()}`;
     appendFileSync(process.env.GITHUB_OUTPUT, `warnings<<${delim}\n${block}\n${delim}\n`);
   }
 } else if (process.env.GITHUB_OUTPUT) {
   // Emit an empty output so the workflow reference never errors.
-  appendFileSync(process.env.GITHUB_OUTPUT, 'warnings<<SYNC_WARNINGS_EOF\nSYNC_WARNINGS_EOF\n');
+  const delim = `SYNC_WARNINGS_EOF_${randomUUID()}`;
+  appendFileSync(process.env.GITHUB_OUTPUT, `warnings<<${delim}\n${delim}\n`);
 }
 
 // Summary

--- a/packages/seo/index.ts
+++ b/packages/seo/index.ts
@@ -4,5 +4,6 @@ export {
   blogPostingJsonLd,
   breadcrumbListJsonLd,
   eventJsonLd,
+  serializeJsonLd,
 } from './src/structured-data.ts';
 export { sitemapConfig } from './src/sitemap.ts';

--- a/packages/seo/src/SecurityHeaders.astro
+++ b/packages/seo/src/SecurityHeaders.astro
@@ -1,8 +1,11 @@
 ---
 // CSP is delivered via meta tags because GitHub Pages does not support custom HTTP headers.
-// Note: frame-ancestors and X-Frame-Options cannot be enforced via meta tags — browsers
-// require those as HTTP response headers. Framing protection requires a CDN (e.g. Cloudflare)
-// in front of GitHub Pages if it becomes a requirement.
+// Note: only Content-Security-Policy and `<meta name="referrer">` are actually honoured
+// as meta tags. frame-ancestors / X-Frame-Options, AND X-Content-Type-Options (nosniff)
+// and Permissions-Policy, are enforced by browsers ONLY as real HTTP response headers —
+// as meta tags they are inert. They are emitted here so the intended policy is documented
+// in one place and takes effect the moment a CDN (e.g. Cloudflare) is put in front of Pages
+// and configured to promote them to response headers; until then they are best-effort.
 // The form API (API Gateway + Lambda) is reached over its exact origin, pinned
 // in connect-src from PUBLIC_API_BASE_URL (empty in local dev, where no API call runs).
 // Cloudflare Turnstile loads its script and challenge iframe from challenges.cloudflare.com.
@@ -18,8 +21,12 @@ const csp = buildContentSecurityPolicy(
 ---
 
 <meta http-equiv="Content-Security-Policy" content={csp} />
-<meta http-equiv="X-Content-Type-Options" content="nosniff" />
 <meta name="referrer" content="strict-origin-when-cross-origin" />
+{
+  /* Inert as meta tags on GitHub Pages (see note above) — kept for documentation
+    and to activate automatically behind a header-capable CDN. */
+}
+<meta http-equiv="X-Content-Type-Options" content="nosniff" />
 <meta
   http-equiv="Permissions-Policy"
   content="camera=(), microphone=(), geolocation=(), payment=(), usb=()"

--- a/packages/seo/src/structured-data.test.ts
+++ b/packages/seo/src/structured-data.test.ts
@@ -5,6 +5,7 @@ import {
   blogPostingJsonLd,
   breadcrumbListJsonLd,
   eventJsonLd,
+  serializeJsonLd,
 } from './structured-data';
 
 describe('organizationJsonLd', () => {
@@ -114,5 +115,25 @@ describe('eventJsonLd', () => {
 
     expect(result.endDate).toBeUndefined();
     expect(result.location).toBeUndefined();
+  });
+});
+
+describe('serializeJsonLd', () => {
+  it('escapes </script> breakout attempts in string values', () => {
+    const output = serializeJsonLd({ name: '</script><script>alert(1)</script>' });
+    expect(output).not.toContain('</script>');
+    expect(output).not.toContain('<script>');
+    expect(output).toContain('\\u003c');
+  });
+
+  it('escapes <, > and & to their \\uXXXX forms', () => {
+    expect(serializeJsonLd({ v: '<' })).toContain('\\u003c');
+    expect(serializeJsonLd({ v: '>' })).toContain('\\u003e');
+    expect(serializeJsonLd({ v: '&' })).toContain('\\u0026');
+  });
+
+  it('produces valid JSON that round-trips back to the original object', () => {
+    const data = { headline: 'A & B < C > D', nested: { url: 'https://bool.pt/</script>' } };
+    expect(JSON.parse(serializeJsonLd(data))).toEqual(data);
   });
 });

--- a/packages/seo/src/structured-data.ts
+++ b/packages/seo/src/structured-data.ts
@@ -1,6 +1,20 @@
 import { t } from '@bool/i18n';
 import { SITE_URL, SITE_NAME, COMPANY } from '@bool/shared';
 
+/**
+ * Serialize a JSON-LD object for embedding in `<script type="application/ld+json"
+ * set:html={...}>`. `JSON.stringify` does not escape `<`, `>`, or `&`, so a string
+ * value containing `</script>` (or `<!--` / `<script`) would close the element and
+ * let arbitrary markup through. Escaping those characters to their `\uXXXX` forms
+ * keeps the payload valid JSON while making script-context breakout impossible.
+ */
+export function serializeJsonLd(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+}
+
 /** Social profile URLs are content-managed in `en.json` (`footer.social.*.href`). */
 const SOCIAL_URL_KEYS = [
   'footer.social.linkedin.href',

--- a/packages/ui/src/compositions/FlipCard/FlipCard.module.css
+++ b/packages/ui/src/compositions/FlipCard/FlipCard.module.css
@@ -29,6 +29,18 @@
   -webkit-backface-visibility: hidden;
   overflow: hidden;
   border-radius: 0;
+  /* Belt-and-braces backface culling: some browsers/GPUs fail to hide the
+     reverse side via `backface-visibility` when a face's children form their
+     own composited layers (here: z-index, filter: grayscale), so the rotated
+     (mirrored) content bleeds through and overlaps the visible face. Toggle
+     `visibility` too, switched at the rotation midpoint (250ms of the 500ms
+     flip) so the hidden face can never paint while the animation is preserved. */
+  transition: visibility 0s 250ms;
+}
+
+/* Back starts hidden; only the front paints until the card flips. */
+.flipCardBack {
+  visibility: hidden;
 }
 
 /* Front face */
@@ -102,11 +114,13 @@
 
 .flipCard:hover .flipCardBack,
 .flipCardInnerFlipped .flipCardBack {
+  visibility: visible;
   pointer-events: auto;
 }
 
 .flipCard:hover .flipCardFront,
 .flipCardInnerFlipped .flipCardFront {
+  visibility: hidden;
   pointer-events: none;
 }
 

--- a/packages/ui/src/layout/BaseLayout/BaseLayout.astro
+++ b/packages/ui/src/layout/BaseLayout/BaseLayout.astro
@@ -2,7 +2,7 @@
 import GoogleAnalytics from '@bool/analytics/GoogleAnalytics.astro';
 import { CookieBanner, CONSENT_ENABLED } from '@bool/compliance';
 import { enKeys, t, tOptional } from '@bool/i18n';
-import { organizationJsonLd, websiteJsonLd } from '@bool/seo';
+import { organizationJsonLd, websiteJsonLd, serializeJsonLd } from '@bool/seo';
 import SecurityHeaders from '@bool/seo/SecurityHeaders.astro';
 import SEOHead from '@bool/seo/SEOHead.astro';
 import ModalHost from '../../compositions/ModalHost/ModalHost';
@@ -146,29 +146,20 @@ const modals = modalKeys.map((key) => ({
       ogImage={ogImage}
       noindex={noindex}
     />
-    {allJsonLd.map((ld) => <script type="application/ld+json" set:html={JSON.stringify(ld)} />)}
+    {allJsonLd.map((ld) => <script type="application/ld+json" set:html={serializeJsonLd(ld)} />)}
     <GoogleAnalytics />
     <script>
       import { initSentry } from '@bool/analytics';
-      import { CONSENT_STORAGE_KEY, CONSENT_ENABLED } from '@bool/compliance';
+      import { getConsent, CONSENT_ENABLED } from '@bool/compliance';
 
       const dsn = import.meta.env.PUBLIC_SENTRY_DSN;
 
       // Gate on CONSENT_ENABLED so Sentry can never load without the consent UI
-      // that lets users grant/withdraw it (GDPR Art. 7(3)).
+      // that lets users grant/withdraw it (GDPR Art. 7(3)). getConsent() validates
+      // the stored record's shape and policy version, so a stale/old-version record
+      // is treated as "no decision" rather than silently re-enabling Sentry.
       if (CONSENT_ENABLED && dsn) {
-        function hasAnalyticsConsent(): boolean {
-          try {
-            const stored = localStorage.getItem(CONSENT_STORAGE_KEY);
-            if (!stored) return false;
-            const consent = JSON.parse(stored);
-            return consent?.analytics === true;
-          } catch {
-            return false;
-          }
-        }
-
-        if (hasAnalyticsConsent()) {
+        if (getConsent()?.analytics === true) {
           void initSentry(dsn);
         } else {
           window.addEventListener('bool:consent-granted', function handler(e: Event) {
@@ -198,6 +189,11 @@ const modals = modalKeys.map((key) => ({
     </main>
     <Footer labels={footerLabels} />
     {CONSENT_ENABLED && <CookieBanner client:load />}
+    {
+      /* client:idle: modals are never visible on first paint (they open from user
+        actions), so defer hydration until the main thread is idle rather than
+        competing with above-the-fold work. */
+    }
     {modals.length > 0 && <ModalHost client:idle modals={modals} closeLabel={t('common.close')} />}
   </body>
 </html>

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,8 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["src/**", "*.ts", "package.json", "tsconfig.json", "astro.config.*"],
-      "outputs": ["dist/**", ".astro/**"]
+      "outputs": ["dist/**", ".astro/**"],
+      "env": ["PUBLIC_*"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
Address findings from a repo security/quality audit:

- CI: add least-privilege permissions blocks to ci/lighthouse/test-drive workflows; SHA-pin every action (was mutable tags) and enable Renovate digest-pinning + a 7-day minimumReleaseAge matching the freshness gate.
- deploy: restrict the Pages publish to refs/heads/master (workflow_dispatch can be launched against any ref).
- seo: add serializeJsonLd() which escapes < > and & so a content-derived JSON-LD value containing a closing script tag cannot break out of the script element; use it in BaseLayout and the blog post page. Add tests.
- seo: document that nosniff and Permissions-Policy are inert as meta tags on Pages (only active behind a header-capable CDN).
- analytics: scrub PII in Sentry beforeSend (redact emails, drop cookies) and set sendDefaultPii false; gate GA and Sentry init on the validated consent record so a stale CONSENT_VERSION cannot silently re-enable tracking.
- web: validate required PUBLIC_ vars on any build (not just CI), with a SKIP_ENV_VALIDATION escape hatch for local vars-less builds.
- media: use an unguessable per-run GITHUB_OUTPUT delimiter for Drive warnings.
- ci: key the turbo build cache on PUBLIC_ so a var change can't serve a stale build.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Testing

- [ ] Unit tests pass (`pnpm test`)
- [ ] E2E tests pass (`pnpm test:e2e`)
- [ ] Type check passes (`pnpm typecheck`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Tested locally in browser

## Screenshots

<!-- If UI changes, add before/after screenshots -->

## Notes

<!-- Anything reviewers should know -->
